### PR TITLE
Support for a Static Factory

### DIFF
--- a/tests/library/Respect/Config/Issues/StaticFactoryTest.php
+++ b/tests/library/Respect/Config/Issues/StaticFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Respect\Config;
+
+class StaticFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group issues
+     * @ticket 9
+     */
+    public function testInstance()
+    {
+        $i = new Instantiator(__NAMESPACE__.'\\StaticTest');
+        $i->setParam('factory', array(array()));
+        $this->assertAttributeNotEmpty('staticMethodCalls', $i);
+        $this->assertInstanceOf('DateTime', $i->getInstance());
+    }
+}
+
+class StaticTest
+{
+    private function __construct() {}
+    public static function factory()
+    {
+        return new \DateTime();
+    }
+}


### PR DESCRIPTION
The change adds a limitation to the added _feature_: Only one static method call must be used when you want to create a instance using a static factory method.
