### PR TITLE
Moving respect/test to be required only on dev installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,9 @@
         }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0"
+    },
+    "require-dev": {
         "respect/test": "dev-master"
     }
 }


### PR DESCRIPTION
Since Respect/Test is a tool for testing purpose, I move it to the section require-dev on composer.

To install with Respect/Test, just use the flag --dev, as the example:  `php composer.phar install --dev`
