### PR TITLE
Add support to nested variables

### DIFF
--- a/tests/library/Respect/Config/ContainerTest.php
+++ b/tests/library/Respect/Config/ContainerTest.php
@@ -41,6 +41,26 @@ INI;
         $this->assertEquals('bat', $c->getItem('baz'));
     }
 
+    public function testLoadNestedArray()
+    {
+        $ini = <<<INI
+db.driver = "mysql"
+db.host   = "localhost"
+db.name   = "my_database"
+db.dsn    = "[db.driver]:host=[db.host];dbname=[db.name]"
+INI;
+
+        $expected = array (
+            'driver'    => 'mysql',
+            'host'      => 'localhost',
+            'name'      => 'my_database',
+            'dsn'       => 'mysql:host=localhost;dbname=my_database',
+        );
+
+        $container = new Container(parse_ini_string($ini, true));
+        $this->assertEquals($expected, $container->getItem('db'));
+    }
+
     public function testLoadFile()
     {
         $c = new Container('exists.ini');


### PR DESCRIPTION
I have to do more tests, but I wanna see what you think about the idea to have nested variables.

**file.ini**

``` ini
db.driver = "mysql"
db.host   = "localhost"
db.name   = "my_database"
db.dsn    = "[db.driver]:host=[db.host];dbname=[db.name]"
```

**file.php**

``` php
$container = new Container('file.ini');
var_export($container->db);
```

**output**

```
array(
    'driver' => 'mysql',
    'host' => 'localhost',
    'name' => 'my_database',
    'dsn' => 'mysql:host=localhost;dbname=my_database',
)
```
