### PR TITLE
Fix container setting closure

### DIFF
--- a/library/Respect/Config/Container.php
+++ b/library/Respect/Config/Container.php
@@ -174,8 +174,12 @@ class Container extends ArrayObject
 
     public function loadArray(array $configurator)
     {
-        foreach ($this->state() + $configurator as $key => $value)
+        foreach ($this->state() + $configurator as $key => $value){
+            if ($value instanceof \Closure) {
+                continue;
+            }
             $this->parseItem($key, $value);
+        }
     }
 
     public function __get($name)

--- a/tests/library/Respect/Config/ContainerTest.php
+++ b/tests/library/Respect/Config/ContainerTest.php
@@ -251,6 +251,16 @@ INI;
         $this->assertEquals('ok', $c->getItem('foo', false));
     }
 
+    public function testClosureWithLoadedFile()
+    {
+        $ini = <<<INI
+respect_blah = ""
+INI;
+        $c = new Container($ini);
+        $c->panda = function() { return 'ok'; };
+        $this->assertEquals('ok', $c->getItem('panda', false));   
+    }
+
     public function testLazyLoadinessOnMultipleConfigLevels()
     {
         $GLOBALS['_SHIT_'] = false;


### PR DESCRIPTION
Hi again! 
I think that a feature documented on [README](https://github.com/cloudson/Config/blob/develop/README.md) is not working. 
I wrote the same example found in the doc:

conf.ini: 

```ini
db_driver = "mysql"
db_host   = "localhost"
db_name   = "my_database"
db_user   = "my_user"
db_pass   = "my_pass"
db_dsn    = "[db_driver]:host=[db_host];dbname=[db_name]"

```
index.php: 

```php
<?php

require __DIR__.'/vendor/autoload.php';

$c = new Respect\Config\Container(__DIR__.'/conf.ini');
$c->connection = function() use($c) {
    return new PDO($c->db_dsn, $c->db_user, $c->db_pass);
};
echo get_class($c->connection); 

```

And I had...
```bash
PHP Warning:  trim() expects parameter 1 to be string, object given in library/Respect/Config/Container.php on line 272

... 
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'Item connection not found' in library/Respect/Config/Container.php:103
```
If you create a container object without pass a file/string on constructor, it works.

well, I created a test case (use it to break tests of version 1.0.1) and a possible fix.

:cloud:  