### PR TITLE
Changing regex for evaluation of a constant

### DIFF
--- a/library/Respect/Config/Container.php
+++ b/library/Respect/Config/Container.php
@@ -267,7 +267,7 @@ class Container extends ArrayObject
 
     protected function parseConstants($value)
     {
-        if (preg_match('/^[A-Z_]+([:]{2}[A-Z_]+)?$/', $value) && defined($value)) {
+        if (preg_match('/^[\\a-zA-Z_]+([:]{2}[A-Z_]+)?$/', $value) && defined($value)) {
             return constant($value);
         } else {
             return $value;

--- a/tests/library/Respect/Config/ContainerTest.php
+++ b/tests/library/Respect/Config/ContainerTest.php
@@ -393,6 +393,28 @@ INI;
         $this->assertInstanceOf('DateTime', $result);
     }
 
+
+    public function testClassConstants()
+    {
+        $ini = <<<INI
+foo = \Respect\Config\TestConstant::CONS_TEST
+INI;
+        $c = new Container;
+        $c->loadArray(parse_ini_string($ini, true));
+        $this->assertEquals(\Respect\Config\TestConstant::CONS_TEST, $c->foo);
+    }
+
+    public function testClassConstantsAnotherNamespace()
+    {
+        class_alias('Respect\Config\TestConstant', 'Respect\Test\Another\Cons');
+        $ini = <<<INI
+foo = \Respect\Test\Another\Cons::CONS_TEST
+INI;
+        $c = new Container;
+        $c->loadArray(parse_ini_string($ini, true));
+        $this->assertEquals(\Respect\Test\Another\Cons::CONS_TEST, $c->foo);
+    }
+
 }
 class Bar {}
 class Foo
@@ -426,6 +448,10 @@ class TypeHintWowMuchType {
     public function __construct(\DateTime $date) {
         $this->d = $date;
     }
+}
+
+class TestConstant {
+    const CONS_TEST = "XPTO";
 }
 
 


### PR DESCRIPTION
This change added the option to use a constant from any namespace.

The issue #39 is resolved by this PR.